### PR TITLE
Unlimited Approval Threshold

### DIFF
--- a/src/YAM_WETH.huff
+++ b/src/YAM_WETH.huff
@@ -1,7 +1,7 @@
 // -- Base constants
 // If changed for alternative chain, replace use of CHAINID in `permit`.
 #define constant MAINNET_CHAIN_ID = 0x01 // Main deployment will be on Ethereum
-#define constant MAX_UINT = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+#define constant UNLIMITED_APPROVAL = 0xff00000000000000000000000000000000000000000000000000000000000000
 #define constant MAX_ADDR = 0xffffffffffffffffffffffffffffffffffffffff
 
 // -- Selector Switch Constants
@@ -257,7 +257,7 @@
     caller msize  mstore // [amount, from]
     msize  <zero> sha3   // [allowance.slot, amount, from]
     dup1 sload           // [allowance, allowance.slot, amount, from]
-    dup1 [MAX_UINT] eq <use_allowance_2pop> jumpi
+    dup1 [UNLIMITED_APPROVAL] lte <use_allowance_2pop> jumpi
     //                      [allowance, allowance.slot, amount, from]
     dup1 dup4            // [amount, allowance, allowance, allowance.slot, amount, from]
     gt insufficient_allowance_error jumpi


### PR DESCRIPTION

The reason to make this change is to make 0xff00...0000 a valid unlimited approval.
Currently 0xffff...ffff is a valid unlimited approval, but if you can approve with 0xff00...0000 instead that is less gas from calldata due to the gas difference between nonzero and zero bytes.
#### Changes
Change eq to gte
Rename MAX_UINT to UNLIMITED_APPROVAL to reflect usage
Set UNLIMITED_APPROVAL to 0xff00...0000