### PR TITLE
👷 Fix small typos and include PUSH0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # METH
 
-> A Wrapped Ether implementation so efficient it'll make your teeth fall out
+> A Wrapped Ether implementation so efficient it'll make your teeth fall out 🦷
 
 "METH" is an overall better version of the commonly used [WETH9](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) contract,
 providing a trustless, immutable and standardized way for smart contracts to abstract away the
@@ -112,7 +112,7 @@ variables. Certain methods also allow contracts to avoid otherwise unused `recei
   ```
 
 ### ⚡ Highly Optimized
-_METH_ is written directly in bytecode-level assembly using the [Huff](https://huff.sh) langauge, ensuring it's implementation is as efficient
+_METH_ is written directly in bytecode-level assembly using the [Huff](https://huff.sh) language, ensuring its implementation is as efficient
 as possible.
 
 ## ⚙️ "METH" under the hood
@@ -140,7 +140,7 @@ A breakdown of the function dispatcher is done here:
 
 Step gas cost|Cumulative gas cost|Op-Code |Stack|Explanation
 -------------|---------------|------------------|-----|----------------
-2|2|PC|[`0`]|Push 0 using 2 instead of 3 gas
+2|2|PUSH0|[`0`]|Push 0 using 2 gas ([EIP-3855](https://eips.ethereum.org/EIPS/eip-3855) included in the Shangai upgrade)
 3|5|CALLDATALOAD|[`calldata[0:32]`]|Load calldata (including selector)
 3|8|PUSH1 0xE0|[`0xe0 (224)`; `calldata[0:32]`]|Push selector offset
 3|11|SHR|[`selector`]|Bitshift right to get 4 upper most bytes of calldata i.e. selector
@@ -159,7 +159,7 @@ Step gas cost|Cumulative gas cost|Op-Code |Stack|Explanation
 
 The final check is slightly modified for the destination of the `receive()` fallback function.
 Instead of `PUSH4 <expected_selector> EQ` it does `CALLDATASIZE ISZERO` costing one less gas.
-Retrieving the selector (`PC CALLDATALOAD PUSh1 0xE0 SHR`) will still work for a call with no calldata as `CALLDATALOAD` reverts to
+Retrieving the selector (`PUSH0 CALLDATALOAD PUSh1 0xE0 SHR`) will still work for a call with no calldata as `CALLDATALOAD` reverts to
 pushing 0 for out-of-bounds calldata. 
 
 If no selector in the ABI has a certain uppermost byte.


### PR DESCRIPTION
There were some small typos in the `README.md` file, along with some things that were no longer true following your PUSH0 usage commit.